### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A Model Context Protocol (MCP) server implementation for the Qwen Max language m
 
 [![smithery badge](https://smithery.ai/badge/@66julienmartin/mcp-server-qwen_max)](https://smithery.ai/server/@66julienmartin/mcp-server-qwen_max)
 
+<a href="https://glama.ai/mcp/servers/1v7po9oa9w"><img width="380" height="200" src="https://glama.ai/mcp/servers/1v7po9oa9w/badge" alt="Qwen Max Server MCP server" /></a>
+
 Why Node.js?
 This implementation uses Node.js/TypeScript as it currently provides the most stable and reliable integration 
 with MCP servers compared to other languages like Python. The Node.js SDK for MCP offers better type safety, 


### PR DESCRIPTION
This PR adds a badge for the [Qwen Max MCP Server](https://glama.ai/mcp/servers/1v7po9oa9w) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/1v7po9oa9w"><img width="380" height="200" src="https://glama.ai/mcp/servers/1v7po9oa9w/badge" alt="Qwen Max Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.